### PR TITLE
Clear timeout before processing the message

### DIFF
--- a/client.js
+++ b/client.js
@@ -127,11 +127,11 @@ function call(config, verb, payload, options) {
   var timeout;
 
   socket.on('message', function(){
+    clearTimeout(timeout);
+    timeout = null;
     var frames = _.toArray(arguments);
     var defer = dfd;
     onMessage(socket, defer, frames);
-    clearTimeout(timeout);
-    timeout = null;
   });
 
   socket.on('error', function(error){

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zmq-service-suite-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
It's possible that due to some conditions(limited CPU, blocked main
thread, errors) that the timeout is not cleared even when there was a
message. By clearing the timeout first we ensure it is given priority
and no matter what happens in the onMessage the timeout is cleared.